### PR TITLE
Migration of Dataprep to GenAI comps 1.2 (To be merged after GenAIExamples1.2)

### DIFF
--- a/comps/dataprep/README.md
+++ b/comps/dataprep/README.md
@@ -56,3 +56,7 @@ For details, please refer to this [readme](src/README_opensearch.md)
 ## Dataprep Microservice with neo4j
 
 For details, please refer to this [readme](src/README_neo4j_llamaindex.md)
+
+## Dataprep Microservice with ArangoDB
+
+For details, please refer to this [readme](src/README_arangodb.md)

--- a/comps/dataprep/deployment/docker_compose/compose.yaml
+++ b/comps/dataprep/deployment/docker_compose/compose.yaml
@@ -12,6 +12,7 @@ include:
   - ../../../third_parties/vdms/deployment/docker_compose/compose.yaml
   - ../../../third_parties/tgi/deployment/docker_compose/compose.yaml
   - ../../../third_parties/tei/deployment/docker_compose/compose.yaml
+  - ../../../third_parties/arangodb/docker_compose/compose.yaml
 
 services:
 
@@ -250,6 +251,61 @@ services:
       VDMS_HOST: ${VDMS_HOST}
       VDMS_PORT: ${VDMS_PORT}
       COLLECTION_NAME: ${INDEX_NAME}
+    restart: unless-stopped
+  
+  dataprep-arangodb:
+    image: ${REGISTRY:-opea}/dataprep:${TAG:-latest}
+    container_name: dataprep-arangodb
+    depends_on:
+      arango-vector-db:
+        condition: service_healthy
+      tgi-gaudi-server:
+        condition: service_healthy
+      tei-embedding-serving:
+        condition: service_healthy
+    ports:
+      - "${DATAPREP_PORT:-11112}:5000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      ARANGO_URL: ${ARANGO_URL}
+      ARANGO_DB_NAME: ${ARANGO_DB_NAME}
+      ARANGO_USERNAME: ${ARANGO_USERNAME}
+      ARANGO_PASSWORD: ${ARANGO_PASSWORD}
+      ARANGO_GRAPH_NAME: ${ARANGO_GRAPH_NAME}
+      ARANGO_USE_GRAPH_NAME: ${ARANGO_USE_GRAPH_NAME}
+      ARANGO_BATCH_SIZE: ${ARANGO_BATCH_SIZE}
+      ARANGO_INSERT_ASYNC: ${ARANGO_INSERT_ASYNC}
+      VLLM_ENDPOINT: ${VLLM_ENDPOINT}
+      VLLM_MODEL_ID: ${VLLM_MODEL_ID}
+      VLLM_MAX_NEW_TOKENS: ${VLLM_MAX_NEW_TOKENS}
+      VLLM_TOP_P: ${VLLM_TOP_P}
+      VLLM_TEMPERATURE: ${VLLM_TEMPERATURE}
+      VLLM_TIMEOUT: ${VLLM_TIMEOUT}
+      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      TEI_EMBED_MODEL: ${TEI_EMBED_MODEL}
+      HUGGINGFACEHUB_API_TOKEN: ${HF_TOKEN}
+      EMBED_SOURCE_DOCUMENTS: ${EMBED_SOURCE_DOCUMENTS}
+      EMBED_NODES: ${EMBED_NODES}
+      EMBED_RELATIONSHIPS: ${EMBED_RELATIONSHIPS}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_EMBED_MODEL: ${OPENAI_EMBED_MODEL}
+      OPENAI_EMBED_DIMENSION: ${OPENAI_EMBED_DIMENSION}
+      OPENAI_CHAT_MODEL: ${OPENAI_CHAT_MODEL}
+      OPENAI_CHAT_TEMPERATURE: ${OPENAI_CHAT_TEMPERATURE}
+      OPENAI_CHAT_ENABLED: ${OPENAI_CHAT_ENABLED}
+      OPENAI_EMBED_ENABLED: ${OPENAI_EMBED_ENABLED}
+      SYSTEM_PROMPT_PATH: ${SYSTEM_PROMPT_PATH}
+      ALLOWED_NODES: ${ALLOWED_NODES}
+      ALLOWED_RELATIONSHIPS: ${ALLOWED_RELATIONSHIPS}
+      NODE_PROPERTIES: ${NODE_PROPERTIES}
+      RELATIONSHIP_PROPERTIES: ${RELATIONSHIP_PROPERTIES}
+      PROCESS_TABLE: ${PROCESS_TABLE}
+      TABLE_STRATEGY: ${TABLE_STRATEGY}
+      CHUNK_SIZE: ${CHUNK_SIZE}
+      CHUNK_OVERLAP: ${CHUNK_OVERLAP}
     restart: unless-stopped
 
 networks:

--- a/comps/dataprep/src/Dockerfile
+++ b/comps/dataprep/src/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missin
     tesseract-ocr \
     libpq-dev \
     libcairo2 \
-    wget
+    wget \
+    git
 
 # Install ffmpeg static build
 RUN cd /root && wget https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz && \

--- a/comps/dataprep/src/README_arangodb.md
+++ b/comps/dataprep/src/README_arangodb.md
@@ -1,0 +1,162 @@
+# Dataprep Microservice with ArangoDB
+
+## 🚀 1. Start Microservice with Python
+
+### Install Requirements
+
+```bash
+pip install -r requirements.txt
+apt-get install libtesseract-dev -y
+apt-get install poppler-utils -y
+```
+
+### Start ArangoDB Server
+
+To launch ArangoDB locally, first ensure you have docker installed. Then, you can launch the database with the following docker command.
+
+```bash
+docker run -d --name arangodb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=password arangodb/arangodb:latest
+```
+
+### Setup Environment Variables
+
+```bash
+export no_proxy=${your_no_proxy}
+export http_proxy=${your_http_proxy}
+export https_proxy=${your_http_proxy}
+export ARANGO_URL=${your_arango_url}
+export ARANGO_USERNAME=${your_arango_username}
+export ARANGO_PASSWORD=${your_arango_password}
+export ARANGO_DB_NAME=${your_db_name}
+export PYTHONPATH=${path_to_comps}
+```
+
+See below for additional environment variables that can be set.
+
+### Start Dataprep Service
+
+```bash
+python prepare_doc_arango.py
+```
+
+## 🚀 2. Start Microservice with Docker
+
+### Build Docker Image
+
+```bash
+cd /your/path/to/GenAIComps
+docker build -t opea/dataprep-arango:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/dataprep/arango/langchain/Dockerfile .
+```
+
+### Run Docker with CLI
+
+```bash
+docker run -d --name="dataprep-arango-server" -p 6007:6007 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e ... opea/dataprep-arango:latest
+```
+
+### Run Docker with Docker Compose
+
+```bash
+cd comps/dataprep/arango/langchain
+docker compose -f docker-compose-dataprep-arango.yaml up -d
+```
+
+## 🚀 3. Consume Retriever Service
+
+An ArangoDB Graph is created from the documents provided to the microservice. The microservice will extract entities from the documents and create nodes and relationships in the graph based on the entities extracted. The microservice will also create embeddings for the documents if embedding environment variables are specified.
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./file1.txt" \
+    -F "graph_name=${your_graph_name}" \
+    http://localhost:6007/v1/dataprep
+```
+
+You can specify the graph name with `-F "graph_name=${your_graph_name}"` in the curl command.
+
+By default, the microservice will create embeddings for the documents if embedding environment variables are specified. You can specify `-F "create_embeddings=false"` to skip document embedding creation.
+
+You can also specify the `chunk_size` and `chunk_overlap` with the following parameters:
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./file1.txt" \
+    -F "chunk_size=1500" \
+    -F "chunk_overlap=100" \
+    -F "graph_name=${your_graph_name}" \
+    http://localhost:6007/v1/dataprep
+```
+
+We support table extraction from pdf documents. You can specify `process_table` and `table_strategy` with the following parameters:
+- `table_strategy` refers to the strategies to understand tables for table retrieval. As the setting progresses from `"fast"` to `"hq"` to `"llm"`, the focus shifts towards deeper table understanding at the expense of processing speed. The default strategy is `"fast"`.
+- `process_table` refers to whether to process tables in the document. The default value is `False`.
+
+Note: If you specify `"table_strategy=llm"`, you should first start the [vLLM Service](https://github.com/opea-project/GenAIComps/tree/main/comps/third_parties/vllm).
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./your_file.pdf" \
+    -F "process_table=true" \
+    -F "table_strategy=hq" \
+    -F "graph_name=${your_graph_name}" \
+    http://localhost:6007/v1/dataprep
+```
+
+---
+
+Additional options that can be specified from the environment variables are as follows (default values are also in the `config.py` file):
+
+ArangoDB Connection configuration
+- `ARANGO_URL`: The URL for the ArangoDB service.
+- `ARANGO_USERNAME`: The username for the ArangoDB service.
+- `ARANGO_PASSWORD`: The password for the ArangoDB service.
+- `ARANGO_DB_NAME`: The name of the database to use for the ArangoDB service.
+
+ArangoDB Graph Insertion configuration
+- `ARANGO_INSERT_ASYNC`: If set to True, the microservice will insert the data into ArangoDB asynchronously. Defaults to `False`.
+- `ARANGO_BATCH_SIZE`: The batch size for the microservice to insert the data. Defaults to `500`.
+- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB Defaults to `GRAPH`. 
+- `ARANGO_USE_GRAPH_NAME`: If set to True, the microservice will use the graph name specified in the environment variable `ARANGO_GRAPH_NAME`. If set to False, the file name will be used as the graph name. Defaults to `True`.
+
+vLLM Configuration
+- `VLLM_ENDPOINT`: The endpoint for the VLLM service. Defaults to `http://localhost:9009`.
+- `VLLM_MODEL_ID`: The model ID for the VLLM service. Defaults to `Intel/neural-chat-7b-v3-3`.
+- `VLLM_MAX_NEW_TOKENS`: The maximum number of new tokens to generate. Defaults to `512`.
+- `VLLM_TOP_P`: If set to < 1, only the smallest set of most probable tokens with probabilities that add up to top_p or higher are kept for generation. Defaults to `0.9`.
+- `VLLM_TEMPERATURE`: The temperature for the sampling. Defaults to `0.8`.
+- `VLLM_TIMEOUT`: The timeout for the VLLM service. Defaults to `600`.
+
+Text Embeddings Inferencing Configuration
+**Note**: This is optional functionality to generate embeddings for documents (i.e text chunks). 
+- `TEI_EMBEDDING_ENDPOINT`: The endpoint for the TEI service.
+- `HUGGINGFACEHUB_API_TOKEN`: The API token for the Hugging Face Hub.
+- `TEI_EMBED_MODEL`: The model to use for the TEI service. Defaults to `BAAI/bge-base-en-v1.5`.
+- `EMBED_SOURCE_DOCUMENTS`: If set to True, the microservice will embed the source documents. Defaults to `True`.
+- `EMBED_NODES`: If set to True, the microservice will embed the nodes extracted from the source documents. Defaults to `False`.
+- `EMBED_RELATIONSHIPS`: If set to True, the microservice will embed the relationships extracted from the source documents. Defaults to `False`.
+
+OpenAI Configuration:
+**Note**: This configuration can replace the VLLM and TEI services for text generation and embeddings.
+- `OPENAI_API_KEY`: The API key for the OpenAI service.
+- `OPENAI_CHAT_MODEL`: The chat model to use for the OpenAI service. Defaults to `gpt-4o`.
+- `OPENAI_CHAT_TEMPERATURE`: The temperature for the OpenAI service. Defaults to `0`.
+- `OPENAI_EMBED_MODEL`: The embedding model to use for the OpenAI service. Defaults to `text-embedding-3-small`.
+- `OPENAI_EMBED_DIMENSION`: The embedding dimension for the OpenAI service. Defaults to `768`.
+- `OPENAI_CHAT_ENABLED`: If set to True, the microservice will use the OpenAI service for text generation, as long as `OPENAI_API_KEY` is also set. Defaults to `True`.
+- `OPENAI_EMBED_ENABLED`: If set to True, the microservice will use the OpenAI service for text embeddings, as long as `OPENAI_API_KEY` is also set. Defaults to `True`.`
+
+[LangChain LLMGraphTransformer](https://api.python.langchain.com/en/latest/graph_transformers/langchain_experimental.graph_transformers.llm.LLMGraphTransformer.html) Configuration:
+- `SYSTEM_PROMPT_PATH`: The path to the system prompt text file. This can be used to specify the specific system prompt for the entity extraction and graph generation steps.
+- `ALLOWED_NODES`: Specifies which node types are allowed in the graph. Defaults to an empty list, allowing all node types.
+- `ALLOWED_RELATIONSHIPS`: Specifies which relationship types are allowed in the graph. Defaults to an empty list, allowing all relationship types.
+- `NODE_PROPERTIES`: If True, the LLM can extract any node properties from text. Alternatively, a list of valid properties can be provided for the LLM to extract, restricting extraction to those specified. Defaults to `["description"]`.
+- `RELATIONSHIP_PROPERTIES`: If True, the LLM can extract any relationship properties from text. Alternatively, a list of valid properties can be provided for the LLM to extract, restricting extraction to those specified. Defaults to `["description"]`.
+
+Parsing Configuration:
+- `PROCESS_TABLE`: If set to True, the microservice will process tables in the document. Defaults to `False`.
+- `TABLE_STRATEGY`: The strategy to understand tables for table retrieval. Defaults to `fast`.
+- `CHUNK_SIZE`: The size of the chunks to process. Defaults to `500`.
+- `CHUNK_OVERLAP`: The overlap between chunks. Defaults to `50`.

--- a/comps/dataprep/src/README_arangodb.md
+++ b/comps/dataprep/src/README_arangodb.md
@@ -15,7 +15,7 @@ apt-get install poppler-utils -y
 To launch ArangoDB locally, first ensure you have docker installed. Then, you can launch the database with the following docker command.
 
 ```bash
-docker run -d --name arangodb -p 8529:8529 -e ARANGO_ROOT_PASSWORD=password arangodb/arangodb:latest
+docker run -d   --name arango-vector-db  -p 8529:8529   -e ARANGO_ROOT_PASSWORD=password   arangodb/arangodb:3.12.4   --experimental-vector-index=true
 ```
 
 ### Setup Environment Variables
@@ -51,7 +51,7 @@ docker build -t opea/dataprep-arango:latest --build-arg https_proxy=$https_proxy
 ### Run Docker with CLI
 
 ```bash
-docker run -d --name="dataprep-arango-server" -p 6007:6007 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e ... opea/dataprep-arango:latest
+docker run -d --name="dataprep-arango-server" -p 6007:5000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e ... opea/dataprep-arango:latest
 ```
 
 ### Run Docker with Docker Compose
@@ -69,11 +69,10 @@ An ArangoDB Graph is created from the documents provided to the microservice. Th
 curl -X POST \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./file1.txt" \
-    -F "graph_name=${your_graph_name}" \
     http://localhost:6007/v1/dataprep
 ```
 
-You can specify the graph name with `-F "graph_name=${your_graph_name}"` in the curl command.
+You can specify the graph name through the `graph_name` variables in arangodb.py.
 
 By default, the microservice will create embeddings for the documents if embedding environment variables are specified. You can specify `-F "create_embeddings=false"` to skip document embedding creation.
 
@@ -85,7 +84,6 @@ curl -X POST \
     -F "files=@./file1.txt" \
     -F "chunk_size=1500" \
     -F "chunk_overlap=100" \
-    -F "graph_name=${your_graph_name}" \
     http://localhost:6007/v1/dataprep
 ```
 
@@ -101,7 +99,6 @@ curl -X POST \
     -F "files=@./your_file.pdf" \
     -F "process_table=true" \
     -F "table_strategy=hq" \
-    -F "graph_name=${your_graph_name}" \
     http://localhost:6007/v1/dataprep
 ```
 
@@ -158,5 +155,5 @@ OpenAI Configuration:
 Parsing Configuration:
 - `PROCESS_TABLE`: If set to True, the microservice will process tables in the document. Defaults to `False`.
 - `TABLE_STRATEGY`: The strategy to understand tables for table retrieval. Defaults to `fast`.
-- `CHUNK_SIZE`: The size of the chunks to process. Defaults to `500`.
-- `CHUNK_OVERLAP`: The overlap between chunks. Defaults to `50`.
+- `CHUNK_SIZE`: The size of the chunks to process. Defaults to `1500`.
+- `CHUNK_OVERLAP`: The overlap between chunks. Defaults to `100`.

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -224,7 +224,7 @@ class OpeaArangoDataprep(OpeaComponent):
             logger.info(f"Connected to ArangoDB {db.version()}.")
 
         
-        self.graph = ArangoGraph(db=db, include_examples=False, generate_schema_on_init=False)
+        self.graph = ArangoGraph(db=db, generate_schema_on_init=False, schema_include_examples=False)
 
         # Perform health check
         health_status = self.check_health()

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -1,0 +1,456 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from typing import List, Optional, Union
+
+import openai
+from arango import ArangoClient
+from fastapi import File, Form, HTTPException, UploadFile
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceHubEmbeddings
+from langchain_community.graphs.arangodb_graph import ArangoGraph
+from langchain_community.llms import HuggingFaceEndpoint
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_experimental.graph_transformers import LLMGraphTransformer
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_text_splitters import HTMLHeaderTextSplitter
+from langchain_core.prompts import ChatPromptTemplate, BasePromptTemplate
+
+
+from comps import CustomLogger, DocPath, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.dataprep.src.utils import (
+    document_loader,
+    encode_filename,
+    get_separators,
+    get_tables_result,
+    parse_html,
+    save_content_to_local_disk,
+)
+
+logger = CustomLogger("OPEA_DATAPREP_ARANGODB")
+logflag = os.getenv("LOGFLAG", False)
+
+
+# Neo4J configuration
+ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
+ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "_system")
+ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
+ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")
+
+# ArangoDB graph configuration
+ARANGO_INSERT_ASYNC = os.getenv("ARANGO_INSERT_ASYNC", False)
+ARANGO_BATCH_SIZE = os.getenv("ARANGO_BATCH_SIZE", 1000)
+ARANGO_USE_GRAPH_NAME = os.getenv("ARANGO_USE_GRAPH_NAME", True)
+ARANGO_GRAPH_NAME = os.getenv("ARANGO_GRAPH_NAME", "GRAPH")
+
+# VLLM configuration
+VLLM_ENDPOINT = os.getenv("VLLM_ENDPOINT")
+VLLM_MODEL_ID = os.getenv("VLLM_MODEL_ID", "Intel/neural-chat-7b-v3-3")
+VLLM_MAX_NEW_TOKENS = os.getenv("VLLM_MAX_NEW_TOKENS", 512)
+VLLM_TOP_P = os.getenv("VLLM_TOP_P", 0.9)
+VLLM_TEMPERATURE = os.getenv("VLLM_TEMPERATURE", 0.8)
+VLLM_TIMEOUT = os.getenv("VLLM_TIMEOUT", 600)
+
+#TGI/TEI configuration
+TEI_EMBEDDING_ENDPOINT = os.getenv("TEI_ENDPOINT")
+TEI_EMBED_MODEL = os.getenv("TEI_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+HUGGINGFACEHUB_API_TOKEN = os.getenv("HUGGINGFACEHUB_API_TOKEN")
+EMBED_SOURCE_DOCUMENTS = os.getenv("EMBED_SOURCE_DOCUMENTS", "true").lower() == "true"
+EMBED_NODES = os.getenv("EMBED_NODES", "false").lower() == "true"
+EMBED_RELATIONSHIPS = os.getenv("EMBED_RELATIONSHIPS", "false").lower() == "true"
+
+# OpenAI configuration (alternative to TGI & TEI)
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_EMBED_MODEL = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
+OPENAI_EMBED_DIMENSION = os.getenv("OPENAI_EMBED_DIMENSION", 512)
+OPENAI_CHAT_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-4o")
+OPENAI_CHAT_TEMPERATURE = os.getenv("OPENAI_CHAT_TEMPERATURE", 0)
+OPENAI_CHAT_ENABLED = os.getenv("OPENAI_CHAT_ENABLED", "true").lower() == "true"
+OPENAI_EMBED_ENABLED = os.getenv("OPENAI_EMBED_ENABLED", "true").lower() == "true"
+
+# LLM/Graph Transformer configuration
+SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH")
+ALLOWED_NODES = os.getenv("ALLOWED_NODES", []) # ["Person", "Organization"]
+ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", []) # [("Person", "knows", "Person"), ("Person", "works_at", "Organization")]
+NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ['description'])
+RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ['description'])
+
+# Parsing configuration
+PROCESS_TABLE = os.getenv("PROCESS_TABLE", "false").lower() == "true"
+TABLE_STRATEGY = os.getenv("TABLE_STRATEGY", "fast")
+CHUNK_SIZE = os.getenv("CHUNK_SIZE", 500)
+CHUNK_OVERLAP = os.getenv("CHUNK_OVERLAP", 100)
+
+@OpeaComponentRegistry.register("OPEA_DATAPREP_ARANGODB")
+class OpeaArangoDataprep(OpeaComponent):
+    """Dataprep component for ArangoDB ingestion and search services."""
+
+    def __init__(self, name: str, description: str, config: dict = None):
+        super().__init__(name, ServiceType.DATAPREP.name.lower(), description, config)
+        self.upload_folder = "./uploaded_files/"
+
+        if ALLOWED_NODES and isinstance(ALLOWED_NODES, str):
+            ALLOWED_NODES = ALLOWED_NODES.split(",")
+
+        if ALLOWED_RELATIONSHIPS and isinstance(ALLOWED_RELATIONSHIPS, str):
+            ALLOWED_RELATIONSHIPS = ALLOWED_RELATIONSHIPS.split(",")
+
+        if NODE_PROPERTIES and isinstance(NODE_PROPERTIES, str):
+            NODE_PROPERTIES = NODE_PROPERTIES.split(",")
+
+        if RELATIONSHIP_PROPERTIES and isinstance(RELATIONSHIP_PROPERTIES, str):
+            RELATIONSHIP_PROPERTIES = RELATIONSHIP_PROPERTIES.split(",")
+        
+        ##############################
+        # Prompt Template (optional) #
+        ##############################
+        
+        PROMPT_TEMPLATE = None
+        if SYSTEM_PROMPT_PATH is not None:
+            try:
+                with open(SYSTEM_PROMPT_PATH, "r") as f:
+                    PROMPT_TEMPLATE = ChatPromptTemplate.from_messages(
+                        [
+                            (
+                                "system",
+                                f.read(),
+                            ),
+                            (
+                                "human",
+                                (
+                                    "Tip: Make sure to answer in the correct format and do "
+                                    "not include any explanations. "
+                                    "Use the given format to extract information from the "
+                                    "following input: {input}"
+                                ),
+                            ),
+                        ]
+                    )
+            except Exception as e:
+                logger.error(f"Could not set custom Prompt: {e}")
+
+        ignore_tool_usage = False
+
+        #############################
+        # Text Generation Inference #
+        #############################
+
+        if OPENAI_API_KEY and OPENAI_CHAT_ENABLED:
+            if logflag:
+                logger.info("OpenAI API Key is set. Verifying its validity...")
+            openai.api_key = OPENAI_API_KEY
+
+            try:
+                openai.models.list()
+                if logflag:
+                    logger.info("OpenAI API Key is valid.")
+                llm = ChatOpenAI(temperature=OPENAI_CHAT_TEMPERATURE, model_name=OPENAI_CHAT_MODEL)
+            except openai.error.AuthenticationError:
+                if logflag:
+                    logger.info("OpenAI API Key is invalid.")
+            except Exception as e:
+                if logflag:
+                    logger.info(f"An error occurred while verifying the API Key: {e}")
+        elif VLLM_ENDPOINT:
+            llm = ChatOpenAI(
+                openai_api_key="EMPTY",
+                openai_api_base=f"{VLLM_ENDPOINT}/v1",
+                model=VLLM_MODEL_ID,
+                temperature=VLLM_TEMPERATURE,
+                max_tokens=VLLM_MAX_NEW_TOKENS,
+                top_p=VLLM_TOP_P,
+                timeout=VLLM_TIMEOUT,
+            )            
+            ignore_tool_usage = True
+        else:
+            raise ValueError("No text generation environment variables are set, cannot generate graphs.")
+        
+        try:
+            llm_transformer = LLMGraphTransformer(
+                llm=llm,
+                allowed_nodes=ALLOWED_NODES,
+                allowed_relationships=ALLOWED_RELATIONSHIPS,
+                prompt=PROMPT_TEMPLATE,
+                node_properties=NODE_PROPERTIES or False,
+                relationship_properties=RELATIONSHIP_PROPERTIES or False,
+                ignore_tool_usage=ignore_tool_usage,
+            )
+        except (TypeError, ValueError) as e:
+            if logflag:
+                logger.warning(f"Advanced LLMGraphTransformer failed: {e}")
+            # Fall back to basic config
+            try:
+                llm_transformer = LLMGraphTransformer(llm=llm, ignore_tool_usage=ignore_tool_usage)
+            except (TypeError, ValueError) as e:
+                if logflag:
+                    logger.error(f"Failed to initialize LLMGraphTransformer: {e}")
+                raise e
+            
+        ########################################
+        # Text Embeddings Inference (optional) #
+        ########################################
+            
+        if OPENAI_API_KEY and OPENAI_EMBED_ENABLED:
+            # Use OpenAI embeddings
+            embeddings = OpenAIEmbeddings(
+                model=OPENAI_EMBED_MODEL,
+                dimensions=OPENAI_EMBED_DIMENSION,
+            )
+
+        elif TEI_EMBEDDING_ENDPOINT and HUGGINGFACEHUB_API_TOKEN:
+            # Use TEI endpoint service
+            embeddings = HuggingFaceHubEmbeddings(
+                model=TEI_EMBEDDING_ENDPOINT,
+                huggingfacehub_api_token=HUGGINGFACEHUB_API_TOKEN,
+            )
+        elif TEI_EMBED_MODEL:
+            # Use local embedding model
+            embeddings = HuggingFaceBgeEmbeddings(model_name=TEI_EMBED_MODEL)
+        else:
+            raise ValueError("No embeddings environment variables are set, cannot generate embeddings.")
+
+        ############
+        # ArangoDB #
+        ############
+
+        client = ArangoClient(hosts=ARANGO_URL)
+        sys_db = client.db(name="_system", username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
+
+        if not sys_db.has_database(ARANGO_DB_NAME):
+            sys_db.create_database(ARANGO_DB_NAME)
+
+        db = client.db(name=ARANGO_DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
+        if logflag:
+            logger.info(f"Connected to ArangoDB {db.version()}.")
+
+        self.llm_transformer = LLMGraphTransformer(
+            llm=llm,
+            allowed_nodes=ALLOWED_NODES,
+            allowed_relationships=ALLOWED_RELATIONSHIPS,
+            prompt=PROMPT_TEMPLATE,
+            node_properties=NODE_PROPERTIES or False,
+            relationship_properties=RELATIONSHIP_PROPERTIES or False,
+            ignore_tool_usage=ignore_tool_usage,
+        )
+        self.graph = ArangoGraph(db=db, include_examples=False, generate_schema_on_init=False)
+
+        # Perform health check
+        health_status = self.check_health()
+        if not health_status:
+            logger.error("OpeaArangoDataprep health check failed.")
+
+    def check_health(self) -> bool:
+        """Checks the health of the ArangoDB service."""
+        if self.graph is None:
+            logger.error("ArangoDB graph is not initialized.")
+            return False
+
+        return True
+
+    def ingest_data_to_arango(self, doc_path: DocPath):
+        """Ingest document to ArangoDB."""
+        path = doc_path.path
+        if logflag:
+            logger.info(f"Parsing document {path}.")
+        ############
+        # Chunking #
+        ############
+        if path.endswith(".html"):
+            headers_to_split_on = [
+                ("h1", "Header 1"),
+                ("h2", "Header 2"),
+                ("h3", "Header 3"),
+            ]
+            text_splitter = HTMLHeaderTextSplitter(headers_to_split_on=headers_to_split_on)
+        else:
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=doc_path.chunk_size,
+                chunk_overlap=doc_path.chunk_overlap,
+                add_start_index=True,
+                separators=get_separators(),
+            )
+
+        content = document_loader(path)
+
+        structured_types = [".xlsx", ".csv", ".json", "jsonl"]
+        _, ext = os.path.splitext(path)
+
+        if ext in structured_types:
+            chunks = content
+        else:
+            chunks = text_splitter.split_text(content)
+
+        if doc_path.process_table and path.endswith(".pdf"):
+            table_chunks = get_tables_result(path, doc_path.table_strategy)
+            if isinstance(table_chunks, list):
+                chunks = chunks + table_chunks
+
+        if logflag:
+            logger.info("Done preprocessing. Created ", len(chunks), " chunks of the original file.")
+        
+        ################################
+        # Graph generation & insertion #
+        ################################
+        if ARANGO_USE_GRAPH_NAME:
+            graph_name = ARANGO_GRAPH_NAME
+        else:
+            file_name = os.path.basename(path).split(".")[0]
+            graph_name = "".join(c for c in file_name if c.isalnum() or c in "_-:.@()+,=;$!*'%")
+
+        if logflag:
+            logger.info(f"Creating graph {graph_name}.")
+
+        for i, text in enumerate(chunks):
+            document = Document(page_content=text)
+
+            if logflag:
+                logger.info(f"Chunk {i}: extracting nodes & relationships.")
+
+            graph_doc = self.llm_transformer.process_response(document)
+
+            if logflag:
+                logger.info(f"Chunk {i}: inserting into ArangoDB.")
+
+            self.graph.add_graph_documents(
+                graph_documents=[graph_doc],
+                include_source=True,
+                graph_name=graph_name,
+                update_graph_definition_if_exists=False,
+                batch_size=ARANGO_BATCH_SIZE,
+                use_one_entity_collection=True,
+                insert_async=ARANGO_INSERT_ASYNC,
+                embeddings=self.embeddings,
+                embedding_field="embedding",
+                embed_source=EMBED_SOURCE_DOCUMENTS,
+                embed_nodes=EMBED_NODES,
+                embed_relationships=EMBED_RELATIONSHIPS,
+            )
+
+            if logflag:
+                logger.info(f"Chunk {i}: processed.")
+
+        if logflag:
+            logger.info("The graph is built.")
+
+        return graph_name
+
+    async def ingest_files(
+        self,
+        files: Optional[Union[UploadFile, List[UploadFile]]] = File(None),
+        link_list: Optional[str] = Form(None),
+        chunk_size: int = Form(CHUNK_SIZE),
+        chunk_overlap: int = Form(CHUNK_OVERLAP),
+        process_table: bool = Form(PROCESS_TABLE),
+        table_strategy: str = Form(TABLE_STRATEGY),
+    ):
+        """Ingest files/links content into ArangoDB database.
+
+        Save in the format of vector[768].
+        Returns '{"status": 200, "message": "Data preparation succeeded"}' if successful.
+        Args:
+            files (Union[UploadFile, List[UploadFile]], optional): A file or a list of files to be ingested. Defaults to File(None).
+            link_list (str, optional): A list of links to be ingested. Defaults to Form(None).
+            chunk_size (int, optional): The size of the chunks to be split. Defaults to Form(500).
+            chunk_overlap (int, optional): The overlap between chunks. Defaults to Form(100).
+            process_table (bool, optional): Whether to process tables in PDFs. Defaults to Form(False).
+            table_strategy (str, optional): The strategy to process tables in PDFs. Defaults to Form("fast").
+        """
+        if logflag:
+            logger.info(f"files:{files}")
+            logger.info(f"link_list:{link_list}")
+
+        if not files and not link_list:
+            raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
+
+        graph_names_created = set()
+
+        if files:
+            if not isinstance(files, list):
+                files = [files]
+            uploaded_files = []
+            for file in files:
+                encode_file = encode_filename(file.filename)
+                save_path = upload_folder + encode_file
+                await save_content_to_local_disk(save_path, file)
+                try:
+                    graph_name = ingest_data_to_arango(
+                        DocPath(
+                            path=save_path,
+                            chunk_size=chunk_size,
+                            chunk_overlap=chunk_overlap,
+                            process_table=process_table,
+                            table_strategy=table_strategy,
+                        ),
+                    )
+
+                    uploaded_files.append(save_path)
+                    graph_names_created.add(graph_name)
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"Failed to ingest {save_path} into ArangoDB: {e}")
+
+                if logflag:
+                    logger.info(f"Successfully saved file {save_path}")
+
+        if link_list:
+            link_list = json.loads(link_list)  # Parse JSON string to list
+            if not isinstance(link_list, list):
+                raise HTTPException(status_code=400, detail="link_list should be a list.")
+            for link in link_list:
+                encoded_link = encode_filename(link)
+                save_path = upload_folder + encoded_link + ".txt"
+                content = parse_html([link])[0][0]
+                await save_content_to_local_disk(save_path, content)
+                try:
+                    graph_name = ingest_data_to_arango(
+                        DocPath(
+                            path=save_path,
+                            chunk_size=chunk_size,
+                            chunk_overlap=chunk_overlap,
+                            process_table=process_table,
+                            table_strategy=table_strategy,
+                        ),
+                    )
+                    graph_names_created.add(graph_name)
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"Failed to ingest {save_path} into ArangoDB: {e}")
+
+                if logflag:
+                    logger.info(f"Successfully saved link {link}")
+
+        graph_names_created = list(graph_names_created)
+
+        result = {
+            "status": 200,
+            "message": f"Data preparation succeeded: {graph_names_created}",
+            "graph_names": graph_names_created,
+        }
+
+        if logflag:
+            logger.info(result)
+
+        return result
+    
+    def invoke(self, *args, **kwargs):
+        pass
+
+    async def get_files(self):
+        """Get file structure from pipecone database in the format of
+        {
+            "name": "File Name",
+            "id": "File Name",
+            "type": "File",
+            "parent": "",
+        }"""
+        pass
+
+    async def delete_files(self, file_path: str = Body(..., embed=True)):
+        """Delete file according to `file_path`.
+
+        `file_path`:
+            - specific file path (e.g. /path/to/file.txt)
+            - "all": delete all files uploaded
+        """
+        pass

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -78,12 +78,6 @@ ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", []) # [("Person", "kn
 NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ['description'])
 RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ['description'])
 
-# # Parsing configuration
-# PROCESS_TABLE = os.getenv("PROCESS_TABLE", "false").lower() == "true"
-# TABLE_STRATEGY = os.getenv("TABLE_STRATEGY", "fast")
-# CHUNK_SIZE = os.getenv("CHUNK_SIZE", 500)
-# CHUNK_OVERLAP = os.getenv("CHUNK_OVERLAP", 100)
-
 @OpeaComponentRegistry.register("OPEA_DATAPREP_ARANGODBgit ")
 class OpeaArangoDataprep(OpeaComponent):
     """Dataprep component for ArangoDB ingestion and search services."""

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -73,7 +73,7 @@ OPENAI_EMBED_ENABLED = os.getenv("OPENAI_EMBED_ENABLED", "true").lower() == "tru
 
 # LLM/Graph Transformer configuration
 SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH")
-ALLOWED_NODES = os.getenv("ALLOWED_NODES", [])  # ["Person", "Organization"]
+ALLOWED_NODES = os.getenv("ALLOWED_NODES", [])
 ALLOWED_RELATIONSHIPS = os.getenv(
     "ALLOWED_RELATIONSHIPS", []
 )  # [("Person", "knows", "Person"), ("Person", "works_at", "Organization")]

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -74,9 +74,7 @@ OPENAI_EMBED_ENABLED = os.getenv("OPENAI_EMBED_ENABLED", "true").lower() == "tru
 # LLM/Graph Transformer configuration
 SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH")
 ALLOWED_NODES = os.getenv("ALLOWED_NODES", [])
-ALLOWED_RELATIONSHIPS = os.getenv(
-    "ALLOWED_RELATIONSHIPS", []
-)  # [("Person", "knows", "Person"), ("Person", "works_at", "Organization")]
+ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", [])
 NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ["description"])
 RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ["description"])
 

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -78,13 +78,13 @@ ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", []) # [("Person", "kn
 NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ['description'])
 RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ['description'])
 
-# Parsing configuration
-PROCESS_TABLE = os.getenv("PROCESS_TABLE", "false").lower() == "true"
-TABLE_STRATEGY = os.getenv("TABLE_STRATEGY", "fast")
-CHUNK_SIZE = os.getenv("CHUNK_SIZE", 500)
-CHUNK_OVERLAP = os.getenv("CHUNK_OVERLAP", 100)
+# # Parsing configuration
+# PROCESS_TABLE = os.getenv("PROCESS_TABLE", "false").lower() == "true"
+# TABLE_STRATEGY = os.getenv("TABLE_STRATEGY", "fast")
+# CHUNK_SIZE = os.getenv("CHUNK_SIZE", 500)
+# CHUNK_OVERLAP = os.getenv("CHUNK_OVERLAP", 100)
 
-@OpeaComponentRegistry.register("OPEA_DATAPREP_ARANGODB")
+@OpeaComponentRegistry.register("OPEA_DATAPREP_ARANGODBgit ")
 class OpeaArangoDataprep(OpeaComponent):
     """Dataprep component for ArangoDB ingestion and search services."""
 
@@ -341,11 +341,11 @@ class OpeaArangoDataprep(OpeaComponent):
         self,
         files: Optional[Union[UploadFile, List[UploadFile]]] = File(None),
         link_list: Optional[str] = Form(None),
-        chunk_size: int = Form(CHUNK_SIZE),
-        chunk_overlap: int = Form(CHUNK_OVERLAP),
-        process_table: bool = Form(PROCESS_TABLE),
-        table_strategy: str = Form(TABLE_STRATEGY),
-    ):
+        chunk_size: int = Form(1500),
+        chunk_overlap: int = Form(100),
+        process_table: bool = Form(False),
+        table_strategy: str = Form("fast"),
+    ):  
         """Ingest files/links content into ArangoDB database.
 
         Save in the format of vector[768].
@@ -373,10 +373,10 @@ class OpeaArangoDataprep(OpeaComponent):
             uploaded_files = []
             for file in files:
                 encode_file = encode_filename(file.filename)
-                save_path = upload_folder + encode_file
+                save_path = self.upload_folder + encode_file
                 await save_content_to_local_disk(save_path, file)
                 try:
-                    graph_name = ingest_data_to_arango(
+                    graph_name = self.ingest_data_to_arango(
                         DocPath(
                             path=save_path,
                             chunk_size=chunk_size,
@@ -400,11 +400,11 @@ class OpeaArangoDataprep(OpeaComponent):
                 raise HTTPException(status_code=400, detail="link_list should be a list.")
             for link in link_list:
                 encoded_link = encode_filename(link)
-                save_path = upload_folder + encoded_link + ".txt"
+                save_path = self.upload_folder + encoded_link + ".txt"
                 content = parse_html([link])[0][0]
                 await save_content_to_local_disk(save_path, content)
                 try:
-                    graph_name = ingest_data_to_arango(
+                    graph_name = self.ingest_data_to_arango(
                         DocPath(
                             path=save_path,
                             chunk_size=chunk_size,

--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -54,7 +54,7 @@ VLLM_TOP_P = os.getenv("VLLM_TOP_P", 0.9)
 VLLM_TEMPERATURE = os.getenv("VLLM_TEMPERATURE", 0.8)
 VLLM_TIMEOUT = os.getenv("VLLM_TIMEOUT", 600)
 
-#TGI/TEI configuration
+# TGI/TEI configuration
 TEI_EMBEDDING_ENDPOINT = os.getenv("TEI_ENDPOINT")
 TEI_EMBED_MODEL = os.getenv("TEI_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
 HUGGINGFACEHUB_API_TOKEN = os.getenv("HUGGINGFACEHUB_API_TOKEN")
@@ -73,10 +73,13 @@ OPENAI_EMBED_ENABLED = os.getenv("OPENAI_EMBED_ENABLED", "true").lower() == "tru
 
 # LLM/Graph Transformer configuration
 SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH")
-ALLOWED_NODES = os.getenv("ALLOWED_NODES", []) # ["Person", "Organization"]
-ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", []) # [("Person", "knows", "Person"), ("Person", "works_at", "Organization")]
-NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ['description'])
-RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ['description'])
+ALLOWED_NODES = os.getenv("ALLOWED_NODES", [])  # ["Person", "Organization"]
+ALLOWED_RELATIONSHIPS = os.getenv(
+    "ALLOWED_RELATIONSHIPS", []
+)  # [("Person", "knows", "Person"), ("Person", "works_at", "Organization")]
+NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ["description"])
+RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ["description"])
+
 
 @OpeaComponentRegistry.register("OPEA_DATAPREP_ARANGODB")
 class OpeaArangoDataprep(OpeaComponent):
@@ -103,24 +106,29 @@ class OpeaArangoDataprep(OpeaComponent):
 
         if relationship_properties and isinstance(relationship_properties, str):
             relationship_properties = relationship_properties.split(",")
-        
+
         ##############################
         # Prompt Template (optional) #
         ##############################
-        
+
         prompt_template = None
         if SYSTEM_PROMPT_PATH is not None:
             try:
                 with open(SYSTEM_PROMPT_PATH, "r") as f:
-                    prompt_template = ChatPromptTemplate.from_messages([
-                        ("system", f.read()),
-                        ("human", (
-                            "Tip: Make sure to answer in the correct format and do "
-                            "not include any explanations. "
-                            "Use the given format to extract information from the "
-                            "following input: {input}"
-                        )),
-                    ])
+                    prompt_template = ChatPromptTemplate.from_messages(
+                        [
+                            ("system", f.read()),
+                            (
+                                "human",
+                                (
+                                    "Tip: Make sure to answer in the correct format and do "
+                                    "not include any explanations. "
+                                    "Use the given format to extract information from the "
+                                    "following input: {input}"
+                                ),
+                            ),
+                        ]
+                    )
             except Exception as e:
                 logger.error(f"Could not set custom Prompt: {e}")
 
@@ -155,11 +163,11 @@ class OpeaArangoDataprep(OpeaComponent):
                 max_tokens=VLLM_MAX_NEW_TOKENS,
                 top_p=VLLM_TOP_P,
                 timeout=VLLM_TIMEOUT,
-            )            
+            )
             ignore_tool_usage = True
         else:
             raise ValueError("No text generation environment variables are set, cannot generate graphs.")
-        
+
         try:
             llm_transformer = LLMGraphTransformer(
                 llm=llm,
@@ -180,11 +188,11 @@ class OpeaArangoDataprep(OpeaComponent):
                 if logflag:
                     logger.error(f"Failed to initialize LLMGraphTransformer: {e}")
                 raise e
-            
+
         ########################################
         # Text Embeddings Inference (optional) #
         ########################################
-            
+
         if OPENAI_API_KEY and OPENAI_EMBED_ENABLED:
             # Use OpenAI embeddings
             self.embeddings = OpenAIEmbeddings(
@@ -246,7 +254,7 @@ class OpeaArangoDataprep(OpeaComponent):
         path = doc_path.path
         if logflag:
             logger.info(f"Parsing document {path}")
-        
+
         ############
         # Chunking #
         ############
@@ -282,7 +290,7 @@ class OpeaArangoDataprep(OpeaComponent):
 
         if logflag:
             logger.info(f"Created {len(chunks)} chunks of the original file")
-        
+
         ################################
         # Graph generation & insertion #
         ################################
@@ -337,7 +345,7 @@ class OpeaArangoDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
-    ):  
+    ):
         """Ingest files/links content into ArangoDB database.
 
         Save in the format of vector[768].
@@ -424,7 +432,7 @@ class OpeaArangoDataprep(OpeaComponent):
             logger.info(result)
 
         return result
-    
+
     def invoke(self, *args, **kwargs):
         pass
 

--- a/comps/dataprep/src/opea_dataprep_microservice.py
+++ b/comps/dataprep/src/opea_dataprep_microservice.py
@@ -16,6 +16,7 @@ from integrations.pipecone import OpeaPineConeDataprep
 from integrations.qdrant import OpeaQdrantDataprep
 from integrations.redis import OpeaRedisDataprep
 from integrations.vdms import OpeaVdmsDataprep
+from integrations.arangodb import OpeaArangoDBDataprep
 from opea_dataprep_loader import OpeaDataprepLoader
 
 from comps import (

--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -15,7 +15,7 @@ huggingface_hub
 ipython
 langchain
 #langchain-community
-git+https://github.com/arangoml/langchain.git@arangodb#subdirectory=libs/community
+git+https://github.com/arangoml/langchain.git@master#subdirectory=libs/community
 langchain-elasticsearch
 langchain-experimental
 langchain-openai

--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4
 cairosvg
+cityhash
 decord
 docarray[full]
 docx2txt
@@ -13,7 +14,8 @@ html2text
 huggingface_hub
 ipython
 langchain
-langchain-community
+#langchain-community
+git+https://github.com/arangoml/langchain.git@arangodb#subdirectory=libs/community
 langchain-elasticsearch
 langchain-experimental
 langchain-openai
@@ -44,6 +46,7 @@ psycopg2
 pymupdf
 pyspark
 pytesseract
+python-arango
 python-bidi
 python-docx
 python-pptx

--- a/comps/third_parties/arangodb/docker_compose/compose.yaml
+++ b/comps/third_parties/arangodb/docker_compose/compose.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  arango-vector-db:
+    image: arangodb/arangodb:3.12.4
+    container_name: arango-vector-db
+    ports:
+      - "8529:8529"
+    environment:
+      ARANGO_ROOT_PASSWORD: ${ARANGO_PASSWORD:-test}
+    command: ["--experimental-vector-index=true"]
+    restart: unless-stopped
+    healthcheck:
+      test: wget http://localhost:8529 || exit 1
+      interval: 5s
+      timeout: 10s
+      retries: 20


### PR DESCRIPTION
## Description

Moved dataprep microservice to new class based implementation. Some functionality is incompatible with newer version, such as the ability to specify the name of the graph to be queried through the curl command.

## Reproduce
Using ChatQnA service
```bash
1. cd ~/Github/GenAIExamples1.2/ChatQnA/docker_compose/intel/cpu/xeon
2. source set_env.sh
3. docker compose up
4. ssh -L 8529:10.128.0.3:8529 -L 6007:10.128.0.3:6007 -L 6006:10.128.0.3:6006 -L 7000:10.128.0.3:7000 -L 8808:10.128.0.3:8808 -L 9009:10.128.0.3:9009 -L 8888:10.128.0.3:8888 -L 5173:10.128.0.3:5173 -L 8081:10.128.0.3:80 user@...
5. Access http://localhost:8081/ on your browser
6. Upload file into GUI using the file picker
```
## Tests

Ran as standalone microservice and as part of ChatQNA megaservice using OpenAI key for graph creation and using TEI Embedding service for embeddings. Default config variables.
