### PR TITLE
Adding functionality to use Denvr endpoint

### DIFF
--- a/comps/dataprep/src/integrations/arangodb.py
+++ b/comps/dataprep/src/integrations/arangodb.py
@@ -48,6 +48,7 @@ ARANGO_USE_GRAPH_NAME = os.getenv("ARANGO_USE_GRAPH_NAME", True)
 ARANGO_GRAPH_NAME = os.getenv("ARANGO_GRAPH_NAME", "GRAPH")
 
 # VLLM configuration
+VLLM_API_KEY = os.getenv("VLLM_API_KEY", "EMPTY")
 VLLM_ENDPOINT = os.getenv("VLLM_ENDPOINT", "http://localhost:80")
 VLLM_MODEL_ID = os.getenv("VLLM_MODEL_ID", "Intel/neural-chat-7b-v3-3")
 VLLM_MAX_NEW_TOKENS = os.getenv("VLLM_MAX_NEW_TOKENS", 512)
@@ -155,7 +156,7 @@ class OpeaArangoDataprep(OpeaComponent):
                     logger.info(f"An error occurred while verifying the API Key: {e}")
         elif VLLM_ENDPOINT:
             llm = ChatOpenAI(
-                openai_api_key="EMPTY",
+                openai_api_key=VLLM_API_KEY,
                 openai_api_base=f"{VLLM_ENDPOINT}/v1",
                 model=VLLM_MODEL_ID,
                 temperature=VLLM_TEMPERATURE,

--- a/comps/retrievers/src/integrations/arangodb.py
+++ b/comps/retrievers/src/integrations/arangodb.py
@@ -35,6 +35,7 @@ from .config import (
     SUMMARIZER_ENABLED,
     TEI_EMBED_MODEL,
     TEI_EMBEDDING_ENDPOINT,
+    VLLM_API_KEY,
     VLLM_ENDPOINT,
     VLLM_MAX_NEW_TOKENS,
     VLLM_MODEL_ID,
@@ -85,7 +86,7 @@ class OpeaArangoRetriever(OpeaComponent):
 
         elif VLLM_ENDPOINT:
             self.llm = ChatOpenAI(
-                openai_api_key="EMPTY",
+                openai_api_key=VLLM_API_KEY,
                 openai_api_base=f"{VLLM_ENDPOINT}/v1",
                 model=VLLM_MODEL_ID,
                 temperature=VLLM_TEMPERATURE,

--- a/comps/retrievers/src/integrations/config.py
+++ b/comps/retrievers/src/integrations/config.py
@@ -188,7 +188,6 @@ SEARCH_ENGINE = "FaissFlat"
 DISTANCE_STRATEGY = "IP"
 
 
-
 #######################################################
 #                     ArangoDB                        #
 #######################################################
@@ -221,6 +220,7 @@ TEI_EMBEDDING_ENDPOINT = os.getenv("TEI_EMBEDDING_ENDPOINT", "")
 HUGGINGFACEHUB_API_TOKEN = os.getenv("HUGGINGFACEHUB_API_TOKEN")
 
 # VLLM configuration
+VLLM_API_KEY = os.getenv("VLLM_API_KEY", "EMPTY")
 VLLM_ENDPOINT = os.getenv("VLLM_ENDPOINT")
 VLLM_MODEL_ID = os.getenv("VLLM_MODEL_ID", "Intel/neural-chat-7b-v3-3")
 VLLM_MAX_NEW_TOKENS = os.getenv("VLLM_MAX_NEW_TOKENS", 512)


### PR DESCRIPTION
## Description

Added functionality to perform inference using vllm on denver endpoint instead of locally for both Dataprep and Retriever

Previous implementation had v1 appended to endpoint which I kept in this version as well `f"{VLLM_ENDPOINT}/v1"`

```bash
# VLLM Configuration
export VLLM_ENDPOINT="https://inference-api.cloud.denvrdata.com/Llama-3.3-70B-Instruct"
export LLM_MODEL_ID="meta-llama/Llama-3.3-70B-Instruct"
export VLLM_API_KEY="..."
```

```python
VLLM_ENDPOINT:
            self.llm = ChatOpenAI(
                openai_api_key=VLLM_API_KEY,
                openai_api_base=f"{VLLM_ENDPOINT}/v1",
                model=VLLM_MODEL_ID,
                temperature=VLLM_TEMPERATURE,
                max_tokens=VLLM_MAX_NEW_TOKENS,
                top_p=VLLM_TOP_P,
                timeout=VLLM_TIMEOUT,
            )
```